### PR TITLE
Fixed a few typos in documentation

### DIFF
--- a/docs/0.4.x/getting-started/creating-a-project.md
+++ b/docs/0.4.x/getting-started/creating-a-project.md
@@ -72,6 +72,6 @@ After your connection was successful, press **Sync In** to move code from the fi
 ## Importing an Existing Project
 Rojo will eventually support importing an existing Roblox project onto the filesystem for use with Rojo.
 
-Rojo doesn't currently support converting an existing project or syncing files from Roblox Studio onto the filesystem. In the mean time, you can manually copy your files into the structure that Rojo expects.
+Rojo doesn't currently support converting an existing project or syncing files from Roblox Studio onto the filesystem. In the meantime, you can manually copy your files into the structure that Rojo expects.
 
 Up-to-date information will be available on [issue #5](https://github.com/LPGhatguy/rojo/issues/5) as this is worked on.

--- a/docs/0.5.x/reference/sync-details.md
+++ b/docs/0.5.x/reference/sync-details.md
@@ -33,7 +33,7 @@ This limitation may be solved by [issue #205](https://github.com/rojo-rbx/rojo/i
 Any directory on the filesystem will turn into a `Folder` instance unless it contains an 'init' script, described below.
 
 ## Scripts
-The default script type in Rojo projects is `ModuleScript`, since most scripts in well-structued Roblox projects will be modules.
+The default script type in Rojo projects is `ModuleScript`, since most scripts in well-structured Roblox projects will be modules.
 
 If a directory contains a file named `init.server.lua`, `init.client.lua`, or `init.lua`, that folder will be transformed into a `*Script` instance with the contents of the 'init' file. This can be used to create scripts inside of scripts.
 

--- a/docs/6.x/existing-game.md
+++ b/docs/6.x/existing-game.md
@@ -10,7 +10,7 @@ Inside Roblox, it is common to have scripts stashed away in instances like GUI c
 
 Roblox games often also contain several copies of the same script, like old school lava bricks in an obstacle course, or the AI behavior for a zombie.
 
-Most software projects ouside Roblox have a single location, like a folder named `src`, that all code goes into. By moving most of your code into services like `ReplicatedStorage`, `ServerScriptService`, and `StarterPlayer`, it becomes easier to find what you're looking for.
+Most software projects outside Roblox have a single location, like a folder named `src`, that all code goes into. By moving most of your code into services like `ReplicatedStorage`, `ServerScriptService`, and `StarterPlayer`, it becomes easier to find what you're looking for.
 
 Rewriting this code to use modern Roblox features like [CollectionService](https://developer.roblox.com/en-us/api-reference/class/CollectionService) can make it easier to understand, easier to work on, and more friendly to Rojo.
 


### PR DESCRIPTION
Fixed around 3 small typos in documentation.

Changes:
- Changed `ouside` > ` outside`
- Changed `well-structued` > `well-structured`
- Changed `mean time` > ` meantime`