### PR TITLE
Correct versioned plugin reference

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -103,8 +103,8 @@ The Rojo plugin can be installed from Roblox.com.
 
 <Link
   className="button button--primary button--extra-margin"
-  to="https://www.roblox.com/library/4048317704/"
->Rojo 6 Plugin on Roblox.com</Link>
+  to="https://www.roblox.com/library/6415005344/Rojo-7"
+>Rojo 7 Plugin on Roblox.com</Link>
 
 :::info
 Rojo has a separate plugin for each major version. Make sure you install the correct one!


### PR DESCRIPTION
Rojo 7 documentation points to the Rojo 6 plugin.