### PR TITLE
Add to the Docs that Unknown Instances will be automatically destroyed

### DIFF
--- a/docs/getting-started/new-game.mdx
+++ b/docs/getting-started/new-game.mdx
@@ -89,6 +89,12 @@ In Roblox Studio, make sure the Rojo plugin is installed. If you need it, check 
 
 To expose your project to the plugin, you'll need to start the **live sync server**.
 
+:::warning
+By default, Rojo clears any unknown instances in a location it syncs to. This means that any instance that is not a part of your Rojo project will automatically be destroyed.
+To disable this, add `$ignoreUnknownInstances` to either the project file or a `.meta.json` for the location you're syncing to.
+To learn more, check out [Sync Details](sync-details.md).
+:::
+
 <Tabs groupId="installation-kind">
 <TabItem value="vscode" label="VS Code" default>
 


### PR DESCRIPTION
Rojo clears any unknown instances in a location it syncs to by default.

You'll need to add `$ignoreUnknownInstances` to either the project file or a .meta.json for the location you're syncing to.

To some people, they may not know this when they start Rojo, because you cannot assume that they are going through every single part of the docs, as they are wanting to get started right away, so they may skip some essential steps. Basically, they risk losing data if they are not acknowledged about this property.

This happened to me, and I lost data because I put Instances in, assuming Rojo wouldn't delete them, but it did since they were unknown.

Not everyone, again, is going to read the whole docs, so just when they install it, it should be a reminder therefore they don't make the same mistakes I did. When someone installs Rojo, they will definitely go through the Getting Started part of the docs, but not in the Sync Details docs if they have no interest.