### PR TITLE
Fixed docs linking in footer under 'Tutorial' button

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -91,7 +91,7 @@ const config = {
           items: [
             {
               label: "Tutorial",
-              to: "/docs",
+              to: "/docs/v7",
             },
           ],
         },


### PR DESCRIPTION
i was trying to read the docs and i noticed the link was wrong, i fixed it.