### PR TITLE
Update title of LPG in blog

### DIFF
--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -1,5 +1,5 @@
 lpg:
   name: Lucien Greathouse
-  title: Primary Maintainer of Rojo
+  title: Original Author of Rojo
   url: https://github.com/LPGhatguy
   image_url: https://github.com/LPGhatguy.png


### PR DESCRIPTION
He is no longer the maintainer, so let's change his title to reflect that.