### PR TITLE
Update installation page

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -34,7 +34,7 @@ Rojo has two pieces that need to be installed:
 <Tabs>
 <TabItem value="aftman" label="With Aftman" default>
 
-[Aftman] is a toolchain manager that is useful for managing tools like Rojo for Roblox projects. To install it, follow these [directions][aftman-installation-directions].
+[Aftman] is a toolchain manager that is useful for managing tools like Rojo for Roblox projects. To install it, follow these [instructions][aftman-installation-instructions].
 
 To install the latest release of Rojo, run the following commands:
 
@@ -44,7 +44,7 @@ aftman install
 ```
 
 [Aftman]: https://github.com/LPGhatguy/aftman
-[aftman-installation-directions]: https://github.com/LPGhatguy/aftman#installation
+[aftman-installation-instructions]: https://github.com/LPGhatguy/aftman#installation
 
 </TabItem>
 <TabItem value="github" label="From GitHub">

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -32,24 +32,19 @@ Rojo has two pieces that need to be installed:
 ## Installing the Server
 
 <Tabs>
-<TabItem value="foreman" label="With Foreman" default>
+<TabItem value="aftman" label="With Aftman" default>
 
-[Foreman] is a toolchain manager that is useful for managing tools like Rojo for Roblox projects.
+[Aftman] is a toolchain manager that is useful for managing tools like Rojo for Roblox projects. To install it, follow these [directions][aftman-installation-directions].
 
-To install from the latest stable release channel of Rojo 6, add an entry to the `[tools]` section of your `foreman.toml`:
+To install the latest release of Rojo, run the following commands:
 
-```toml
-[tools]
-rojo = { source = "rojo-rbx/rojo", version = "7" }
+```bash
+aftman add rojo-rbx/rojo
+aftman install
 ```
 
-After adding the entry above, run the command below so Foreman can download and install Rojo.
-
-```
-foreman install
-```
-
-[Foreman]: https://github.com/rojo-rbx/foreman
+[Aftman]: https://github.com/LPGhatguy/aftman
+[aftman-installation-directions]: https://github.com/LPGhatguy/aftman#installation
 
 </TabItem>
 <TabItem value="github" label="From GitHub">

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -112,10 +112,6 @@ The Rojo plugin can be installed from Roblox.com.
   to="https://www.roblox.com/library/13916111004/Rojo"
 >Rojo 7 Plugin on Roblox.com</Link>
 
-:::info
-Rojo has a separate plugin for each major version. Make sure you install the correct one!
-:::
-
 Press the 'Install' button on the plugin page to add it to Roblox Studio.
 
 </TabItem>


### PR DESCRIPTION
This PR changes the foreman recommendation to aftman. It also removes a few rojo version numbers which will make updating docs a little easier.

I also removed the info section in the cloud plugin installation section since it doesn't apply.