### PR TITLE
Update github-pages-deploy-action to v4.5.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm run build
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4.1.5
+        uses: JamesIves/github-pages-deploy-action@v4.4.3
         with:
           branch: gh-pages
           folder: build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install Node.js Dependencies
         run: npm ci
@@ -30,7 +30,7 @@ jobs:
         run: npm run build
 
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@v4.4.3
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           branch: gh-pages
           folder: build


### PR DESCRIPTION
The version we currently use is outdated and utilizes a flag that is deprecated.

~~I'm choosing to upgrade to v4.4.3 instead of v4.5.0 because the latter uses Node 20, whereas v4.4.3 uses Node 16. I don't know what the consequence of using Node 20 would be at this time, but until there's a compelling reason to upgrade we may as well not bother because there's no security risk associated with static sites.~~

The site works fine with Node 20, so we're just going to upgrade to the latest release.