### PR TITLE
Add clearer instructions for VSCode users

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -22,6 +22,42 @@ The VS Code extension does not add `rojo` to your system PATH. In order to use R
 
 [extension]: https://marketplace.visualstudio.com/items?itemName=evaera.vscode-rojo
 
+## Installing the Plugin
+
+<Tabs>
+<TabItem value="github" label="From GitHub">
+
+The Rojo plugin is available from Rojo's GitHub Releases page.
+
+<Link
+  className="button button--primary button--extra-margin"
+  to="https://github.com/rojo-rbx/rojo/releases"
+>Rojo GitHub Releases</Link>
+
+:::info
+Rojo has a separate plugin for each major version. Make sure you install the correct one!
+:::
+
+Download the attached `rbxm` file and put it into your Roblox Studio plugins folder. You can find that folder by pressing **Plugins Folder** from your Plugins toolbar in Roblox Studio:
+
+!['Plugins Folder' button in Roblox Studio](/img/plugins-folder-in-studio.png)
+
+</TabItem>
+<TabItem value="roblox" label="From Roblox.com">
+
+The Rojo plugin can be installed from Roblox.com.
+
+<Link
+  className="button button--primary button--extra-margin"
+  to="https://www.roblox.com/library/13916111004/Rojo"
+>Rojo 7 Plugin on Roblox.com</Link>
+
+Press the 'Install' button on the plugin page to add it to Roblox Studio.
+
+</TabItem>
+
+</Tabs>
+
 </TabItem>
 <TabItem value="cli" label="CLI">
 


### PR DESCRIPTION
For the Installation section of the docs, adding Rojo plugin installation tab in the VSCode tab for easier access in both tabs.